### PR TITLE
Switch to Maven based dependency

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,10 @@
-def owPath = System.getenv("OPENWHISK_HOME") ?: '../open'
-def owDirectory = new File(owPath)
-
-include 'common:scala'; project(':common:scala').projectDir = new File(owDirectory, 'common/scala')
-include 'core:controller'; project(':core:controller').projectDir = new File(owDirectory, 'core/controller')
-include 'core:invoker'; project(':core:invoker').projectDir = new File(owDirectory, 'core/invoker')
-include 'whisktests'; project(':whisktests').projectDir = new File(owDirectory, 'tests')
-
 include 'tests'
 
 rootProject.name = 'openwhisk-package-deploy'
+
+gradle.ext.openwhisk = [
+        version: '1.0.0-SNAPSHOT'
+]
 
 gradle.ext.scala = [
     version: '2.11.8',

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -2,10 +2,9 @@ apply plugin: 'scala'
 apply plugin: 'eclipse'
 compileTestScala.options.encoding = 'UTF-8'
 
-evaluationDependsOn(':whisktests')
-
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 tasks.withType(Test) {
@@ -19,8 +18,8 @@ tasks.withType(Test) {
 
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
-    compile project(':whisktests')
-    compile project(':whisktests').sourceSets.test.output
+    compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:tests"
+    compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:test-sources"
 }
 
 tasks.withType(ScalaCompile) {

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -28,7 +28,12 @@ $ANSIBLE_CMD initdb.yml
 
 cd $WHISKDIR
 
-TERM=dumb ./gradlew distDocker
+TERM=dumb ./gradlew \
+:common:scala:install \
+:core:controller:install \
+:core:invoker:install \
+:tests:install \
+distDocker
 
 cd $WHISKDIR/ansible
 


### PR DESCRIPTION
This is required for apache/incubator-openwhisk#3277

Post this change for development you would need to install dependencies from the root directory on $OPENWHISK_HOME repository
```
./gradlew install
```