### PR TITLE
Adding :admin:tools:install task to the travis build.sh

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -33,6 +33,7 @@ TERM=dumb ./gradlew \
 :core:controller:install \
 :core:invoker:install \
 :tests:install \
+:tools:admin:install \
 distDocker
 
 cd $WHISKDIR/ansible


### PR DESCRIPTION
Fixes the build failure in https://travis-ci.org/apache/incubator-openwhisk-package-deploy/builds/397639327

The related issue on openwhisk repository https://github.com/apache/incubator-openwhisk/issues/3823