### PR TITLE
Switch to Scala 2.12.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 
 language: scala
 scala:
-   - 2.11.6
+   - 2.12.7
 
 services:
   - docker

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,6 @@ gradle.ext.openwhisk = [
 ]
 
 gradle.ext.scala = [
-    version: '2.11.8',
+    version: '2.12.7',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -12,9 +12,6 @@ UTILDIR="$ROOTDIR/../incubator-openwhisk-utilities"
 cd $UTILDIR
 scancode/scanCode.py $ROOTDIR
 
-# run jshint
-cd $ROOTDIR/packages
-jshint .
 
 # Install OpenWhisk
 cd $WHISKDIR/ansible

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -12,7 +12,7 @@ cd $HOMEDIR
 git clone https://github.com/apache/incubator-openwhisk-utilities.git
 
 # shallow clone OpenWhisk repo.
-git clone --depth=1 --single-branch -b scala-2-12 https://github.com/chetanmeh/incubator-openwhisk.git openwhisk
+git clone --depth 1 https://github.com/apache/incubator-openwhisk.git openwhisk
 
 cd openwhisk
 ./tools/travis/setup.sh

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -3,10 +3,6 @@
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 HOMEDIR="$SCRIPTDIR/../../../"
 
-# jshint support
-sudo apt-get -y install nodejs npm
-sudo npm install -g jshint
-
 # clone utilties repo. in order to run scanCode.py
 cd $HOMEDIR
 git clone https://github.com/apache/incubator-openwhisk-utilities.git

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -12,7 +12,7 @@ cd $HOMEDIR
 git clone https://github.com/apache/incubator-openwhisk-utilities.git
 
 # shallow clone OpenWhisk repo.
-git clone --depth 1 https://github.com/apache/incubator-openwhisk.git openwhisk
+git clone --depth=1 --single-branch -b scala-2-12 https://github.com/chetanmeh/incubator-openwhisk.git openwhisk
 
 cd openwhisk
 ./tools/travis/setup.sh


### PR DESCRIPTION
Switches Scala version to 2.12.7 as part of apache/incubator-openwhisk#3952

To validate that build passes fine this PR build against the [scala-2-12][1] branch. Following sequence of steps would happen

1. apache/incubator-openwhisk#4062 is merged
2. Change the git url in install scripts
3. Merge this PR

[1]: https://github.com/chetanmeh/incubator-openwhisk/tree/scala-2-12